### PR TITLE
Fixed pemissions to create release

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -41,6 +41,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [get-package-name, publish-python-package]
+    permissions:
+      contents: write
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v5


### PR DESCRIPTION
Fixed `CD.yml` by adding `permissions: contents: write` to the `Create Release` job.